### PR TITLE
Implement optional caching

### DIFF
--- a/ndatabase-api/src/main/java/com/nivixx/ndatabase/api/NDatabaseAPI.java
+++ b/ndatabase-api/src/main/java/com/nivixx/ndatabase/api/NDatabaseAPI.java
@@ -26,4 +26,11 @@ public interface NDatabaseAPI {
      */
     <K,V extends NEntity<K>> Repository<K,V> getOrCreateRepository(Class<V> entityType) throws NDatabaseException;
 
+    /**
+     * Call this method in the shutdown hook of the plugin. This ensures that the cache is properly flushed and
+     * everything is saved.
+     *
+     * @throws NDatabaseException If a commit to the database has failed
+     */
+    void shutdown() throws NDatabaseException;
 }

--- a/ndatabase-api/src/main/java/com/nivixx/ndatabase/api/annotation/UseCache.java
+++ b/ndatabase-api/src/main/java/com/nivixx/ndatabase/api/annotation/UseCache.java
@@ -1,0 +1,10 @@
+package com.nivixx.ndatabase.api.annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface UseCache {
+}

--- a/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/DatabaseTypeResolver.java
+++ b/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/DatabaseTypeResolver.java
@@ -14,7 +14,6 @@ import com.nivixx.ndatabase.dbms.mysql.MysqlDao;
 import com.nivixx.ndatabase.dbms.sqlite.SqliteConnectionPool;
 import com.nivixx.ndatabase.dbms.sqlite.SqliteDao;
 import com.nivixx.ndatabase.platforms.coreplatform.logging.DBLogger;
-import net.byteflux.libby.LibraryManager;
 
 import java.lang.annotation.Annotation;
 

--- a/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/NDatabaseAPIImpl.java
+++ b/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/NDatabaseAPIImpl.java
@@ -1,6 +1,5 @@
 package com.nivixx.ndatabase.core;
 
-import com.google.inject.Inject;
 import com.nivixx.ndatabase.api.NDatabaseAPI;
 import com.nivixx.ndatabase.api.exception.NDatabaseException;
 import com.nivixx.ndatabase.api.model.NEntity;
@@ -17,5 +16,10 @@ public class NDatabaseAPIImpl implements NDatabaseAPI {
 
     public <K,V extends NEntity<K>> Repository<K,V> getOrCreateRepository(Class<V> entityType) throws NDatabaseException {
         return bloodyDaoManager.getOrCreateRepository(entityType);
+    }
+
+    @Override
+    public void shutdown() throws NDatabaseException {
+        bloodyDaoManager.shutdownCache();
     }
 }

--- a/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/PlatformLoader.java
+++ b/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/PlatformLoader.java
@@ -40,7 +40,7 @@ public abstract class PlatformLoader extends AbstractModule {
                 bind(DatabaseConnection.class).toInstance(hikariConnectionPool);
                 break;
             case MARIADB:
-                HikariMariaConnectionPool hikariConnectionPoolMaria = new HikariMariaConnectionPool(nDatabaseConfig.getMariaDBConfig());
+                HikariMariaConnectionPool hikariConnectionPoolMaria = new HikariMariaConnectionPool(nDatabaseConfig.getMariaDBConfig(), dbLogger, libraryManager);
                 bind(HikariMariaConnectionPool.class).toInstance(hikariConnectionPoolMaria);
                 bind(DatabaseConnection.class).toInstance(hikariConnectionPoolMaria);
                 break;

--- a/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/RepositoryManager.java
+++ b/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/RepositoryManager.java
@@ -79,7 +79,6 @@ public class RepositoryManager<K,V extends NEntity<K>> {
             String pluginName = extractPluginName(classLoader.toString());
             pluginEntityMap.computeIfAbsent(pluginName, k -> ConcurrentHashMap.newKeySet())
                     .add(entityType);
-            System.out.println("Associating entity " + entityType + " with plugin " + pluginName);
         }
 
         return repository;
@@ -96,38 +95,31 @@ public class RepositoryManager<K,V extends NEntity<K>> {
             for (Class<V> entityClass : pluginEntities) {
                 Repository<K,V> repository = repositoryCache.get(entityClass);
                 if (repository instanceof CachedRepositoryImpl) {
-                    System.out.println("Shutting down cache for " + entityClass);
                     ((CachedRepositoryImpl<K,V>) repository).shutdown();
                 }
             }
         }
 
         pluginEntityMap.remove(callingPlugin);
-
-        System.out.println("Size of pluginEntityMap after flushing caches: " + pluginEntityMap.size());
     }
 
     private String findCallingPlugin() {
-        System.out.println("Finding calling plugin");
         StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
         for (int i = 2; i < stackTrace.length; i++) {
             try {
                 Class<?> callingClass = Class.forName(stackTrace[i].getClassName());
                 ClassLoader classLoader = callingClass.getClassLoader();
-                System.out.println("Checking class loader " + classLoader);
                 if (classLoader != null &&
                         classLoader.toString().contains("PluginClassLoader") &&
                         !classLoader.toString().contains("NDatabase")) {
                     String pluginName = extractPluginName(classLoader.toString());
                     if (pluginName != null) {
-                        System.out.println("Found calling plugin " + pluginName);
                         return pluginName;
                     }
                 }
             } catch (ClassNotFoundException ignored) {}
         }
 
-        System.out.println("Could not find calling plugin");
         return null;
     }
 

--- a/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/cache/CacheRepoConfig.java
+++ b/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/cache/CacheRepoConfig.java
@@ -1,0 +1,67 @@
+package com.nivixx.ndatabase.core.cache;
+
+public class CacheRepoConfig {
+    private long expireAfterAccessMinutes;
+    private long maximumSize;
+    private int getTimeoutSeconds;
+    private boolean enableSoftValues;
+    private boolean enableRefreshAfterWrite;
+    private long refreshAfterWriteMinutes;
+    private boolean enableStats;
+
+    public long getExpireAfterAccessMinutes() {
+        return expireAfterAccessMinutes;
+    }
+
+    public void setExpireAfterAccessMinutes(long expireAfterAccessMinutes) {
+        this.expireAfterAccessMinutes = expireAfterAccessMinutes;
+    }
+
+    public long getMaximumSize() {
+        return maximumSize;
+    }
+
+    public void setMaximumSize(long maximumSize) {
+        this.maximumSize = maximumSize;
+    }
+
+    public int getGetTimeoutSeconds() {
+        return getTimeoutSeconds;
+    }
+
+    public void setGetTimeoutSeconds(int getTimeoutSeconds) {
+        this.getTimeoutSeconds = getTimeoutSeconds;
+    }
+
+    public boolean isEnableSoftValues() {
+        return enableSoftValues;
+    }
+
+    public void setEnableSoftValues(boolean enableSoftValues) {
+        this.enableSoftValues = enableSoftValues;
+    }
+
+    public boolean isEnableRefreshAfterWrite() {
+        return enableRefreshAfterWrite;
+    }
+
+    public void setEnableRefreshAfterWrite(boolean enableRefreshAfterWrite) {
+        this.enableRefreshAfterWrite = enableRefreshAfterWrite;
+    }
+
+    public long getRefreshAfterWriteMinutes() {
+        return refreshAfterWriteMinutes;
+    }
+
+    public void setRefreshAfterWriteMinutes(long refreshAfterWriteMinutes) {
+        this.refreshAfterWriteMinutes = refreshAfterWriteMinutes;
+    }
+
+    public boolean isEnableStats() {
+        return enableStats;
+    }
+
+    public void setEnableStats(boolean enableStats) {
+        this.enableStats = enableStats;
+    }
+}

--- a/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/cache/CachedRepositoryImpl.java
+++ b/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/cache/CachedRepositoryImpl.java
@@ -1,0 +1,262 @@
+package com.nivixx.ndatabase.core.cache;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.nivixx.ndatabase.api.Promise;
+import com.nivixx.ndatabase.api.exception.NDatabaseException;
+import com.nivixx.ndatabase.api.model.NEntity;
+import com.nivixx.ndatabase.api.query.NQuery;
+import com.nivixx.ndatabase.api.repository.Repository;
+import com.nivixx.ndatabase.core.promise.AsyncThreadPool;
+import com.nivixx.ndatabase.core.promise.pipeline.PromiseEmptyResultPipeline;
+import com.nivixx.ndatabase.core.promise.pipeline.PromiseResultPipeline;
+import com.nivixx.ndatabase.dbms.api.Dao;
+import com.nivixx.ndatabase.platforms.coreplatform.executor.SyncExecutor;
+import com.nivixx.ndatabase.platforms.coreplatform.logging.DBLogger;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class CachedRepositoryImpl<K, V extends NEntity<K>> implements Repository<K, V> {
+
+    private final AsyncLoadingCache<K, V> cache;
+
+    private final SyncExecutor syncExecutor;
+    private final AsyncThreadPool asyncThreadPool;
+    private final DBLogger dbLogger;
+    private final CacheRepoConfig cacheConfig;
+
+    public CachedRepositoryImpl(Dao<K, V> dao,
+                          Class<V> classz,
+                          SyncExecutor syncExecutor,
+                          AsyncThreadPool asyncThreadPool,
+                          DBLogger dbLogger,
+                          CacheRepoConfig cacheConfig) {
+        this.syncExecutor = syncExecutor;
+        this.asyncThreadPool = asyncThreadPool;
+        this.dbLogger = dbLogger;
+        this.cacheConfig = cacheConfig;
+
+        Caffeine<Object, Object> builder = Caffeine.newBuilder()
+                .expireAfterAccess(cacheConfig.getExpireAfterAccessMinutes(), TimeUnit.MINUTES)
+                .maximumSize(cacheConfig.getMaximumSize())
+                .executor(asyncThreadPool.getExecutor());
+
+        if (cacheConfig.isEnableStats()) {
+            builder.recordStats();
+        }
+
+        if (cacheConfig.isEnableSoftValues()) {
+            builder.softValues();
+        }
+
+        if (cacheConfig.isEnableRefreshAfterWrite()) {
+            builder.refreshAfterWrite(cacheConfig.getRefreshAfterWriteMinutes(), TimeUnit.MINUTES);
+        }
+
+        this.cache = builder
+                .evictionListener((K key, V value, RemovalCause cause) -> {
+                    if (value != null && (cause.wasEvicted() || cause == RemovalCause.REPLACED)) {
+                        dao.upsert(value);
+                    }
+                })
+                .buildAsync((key, executor) -> CompletableFuture.supplyAsync(
+                        () -> dao.get(key, classz),
+                        asyncThreadPool.getExecutor()
+                ));
+
+    }
+
+    @Override
+    public V get(K key) throws NDatabaseException {
+        try {
+            return cache.get(key).get(cacheConfig.getGetTimeoutSeconds(), TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new NDatabaseException("Failed to get value from cache", e);
+        }
+    }
+
+    @Override
+    public Promise.AsyncResult<V> getAsync(K key) {
+        return new PromiseResultPipeline<>(cache.get(key), syncExecutor, asyncThreadPool, dbLogger);
+    }
+
+    @Override
+    public Promise.AsyncResult<Optional<V>> findOneAsync(Predicate<V> predicate) {
+        CompletableFuture<Optional<V>> future = CompletableFuture.supplyAsync(() ->
+                        cache.synchronous()
+                                .asMap()
+                                .values()
+                                .stream()
+                                .filter(predicate)
+                                .findFirst(),
+                asyncThreadPool.getExecutor()
+        );
+        return new PromiseResultPipeline<>(future, syncExecutor, asyncThreadPool, dbLogger);
+    }
+
+    @Override
+    public Promise.AsyncResult<Optional<V>> streamAndFindOneAsync(Predicate<V> predicate) {
+        return findOneAsync(predicate);
+    }
+
+    @Override
+    public Promise.AsyncResult<List<V>> findAsync(Predicate<V> predicate) {
+        CompletableFuture<List<V>> future = CompletableFuture.supplyAsync(() ->
+                        cache.synchronous()
+                                .asMap()
+                                .values()
+                                .stream()
+                                .filter(predicate)
+                                .collect(Collectors.toList()),
+                asyncThreadPool.getExecutor()
+        );
+        return new PromiseResultPipeline<>(future, syncExecutor, asyncThreadPool, dbLogger);
+    }
+
+    @Override
+    public Promise.AsyncResult<List<V>> streamAndFindAsync(Predicate<V> predicate) {
+        return findAsync(predicate);
+    }
+
+    @Override
+    public void insert(V value) throws NDatabaseException {
+        if (value == null) {
+            throw new NDatabaseException("Cannot insert null value");
+        }
+        cache.synchronous().put(value.getKey(), value);
+    }
+
+    @Override
+    public Promise.AsyncEmptyResult insertAsync(V value) {
+        if (value == null) {
+            return new PromiseEmptyResultPipeline<>(
+                    CompletableFuture.supplyAsync(() -> { throw new NDatabaseException("Cannot insert null value"); }),
+                    syncExecutor, asyncThreadPool, dbLogger
+            );
+        }
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() ->
+                        cache.put(value.getKey(), CompletableFuture.completedFuture(value)),
+                asyncThreadPool.getExecutor()
+        );
+        return new PromiseEmptyResultPipeline<>(future, syncExecutor, asyncThreadPool, dbLogger);
+    }
+
+    @Override
+    public void upsert(V value) throws NDatabaseException {
+        insert(value);
+    }
+
+    @Override
+    public Promise.AsyncEmptyResult upsertAsync(V value) {
+        return insertAsync(value);
+    }
+
+    @Override
+    public void update(V value) throws NDatabaseException {
+        insert(value);
+    }
+
+    @Override
+    public Promise.AsyncEmptyResult updateAsync(V value) {
+        return insertAsync(value);
+    }
+
+    @Override
+    public void delete(K key) throws NDatabaseException {
+        cache.synchronous().asMap().remove(key);
+    }
+
+    @Override
+    public Promise.AsyncEmptyResult deleteAsync(K key)  {
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> cache.asMap().remove(key));
+        return new PromiseEmptyResultPipeline<>(future, syncExecutor, asyncThreadPool, dbLogger);
+    }
+
+    @Override
+    public void delete(V value) throws NDatabaseException {
+        delete(value.getKey());
+    }
+
+    @Override
+    public Promise.AsyncEmptyResult deleteAsync(V value)  {
+        return deleteAsync(value.getKey());
+    }
+
+    @Override
+    public void deleteAll() throws NDatabaseException {
+        cache.synchronous().asMap().clear();
+    }
+
+    @Override
+    public Promise.AsyncEmptyResult deleteAllAsync() throws NDatabaseException {
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> cache.asMap().clear());
+        return new PromiseEmptyResultPipeline<>(future, syncExecutor, asyncThreadPool, dbLogger);
+    }
+
+    @Override
+    public Stream<V> streamAllValues() throws NDatabaseException {
+        return cache.synchronous().asMap().values().stream();
+    }
+
+    @Override
+    public Promise.AsyncResult<Stream<V>> streamAllValuesAsync() throws NDatabaseException {
+        CompletableFuture<Stream<V>> future = CompletableFuture.supplyAsync(() ->
+                        cache.synchronous()
+                                .asMap()
+                                .values()
+                                .stream(),
+                asyncThreadPool.getExecutor()
+        );
+        return new PromiseResultPipeline<>(future, syncExecutor, asyncThreadPool, dbLogger);
+    }
+
+    @Override
+    public Promise.AsyncResult<List<V>> computeTopAsync(int topMax, Comparator<V> comparator) {
+        CompletableFuture<List<V>> future = CompletableFuture.supplyAsync(() ->
+                        cache.synchronous()
+                                .asMap()
+                                .values()
+                                .stream()
+                                .sorted(comparator)
+                                .limit(topMax)
+                                .collect(Collectors.toList()),
+                asyncThreadPool.getExecutor()
+        );
+        return new PromiseResultPipeline<>(future, syncExecutor, asyncThreadPool, dbLogger);
+    }
+
+    @Override
+    public Optional<V> findOne(NQuery.Predicate predicate) {
+        throw new UnsupportedOperationException("The provided predicate is SQL-based and cannot be applied to in-memory objects.");
+    }
+
+    @Override
+    public Promise.AsyncResult<Optional<V>> findOneAsync(NQuery.Predicate predicate) {
+        throw new UnsupportedOperationException("The provided predicate is SQL-based and cannot be applied to in-memory objects.");
+    }
+
+    @Override
+    public List<V> find(NQuery.Predicate predicate) {
+        throw new UnsupportedOperationException("The provided predicate is SQL-based and cannot be applied to in-memory objects.");
+    }
+
+    @Override
+    public Promise.AsyncResult<List<V>> findAsync(NQuery.Predicate predicate) {
+        throw new UnsupportedOperationException("The provided predicate is SQL-based and cannot be applied to in-memory objects.");
+    }
+
+    public Promise.AsyncResult<Map<K, V>> getAllAsync(Collection<K> keys) {
+        CompletableFuture<Map<K, V>> future = cache.getAll(keys);
+        return new PromiseResultPipeline<>(future, syncExecutor, asyncThreadPool, dbLogger);
+    }
+
+    public void flushCache() {
+        cache.synchronous().invalidateAll();
+    }
+}

--- a/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/config/NDatabaseConfig.java
+++ b/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/config/NDatabaseConfig.java
@@ -1,5 +1,6 @@
 package com.nivixx.ndatabase.core.config;
 
+import com.nivixx.ndatabase.core.cache.CacheRepoConfig;
 import com.nivixx.ndatabase.dbms.mariadb.MariaDBConfig;
 import com.nivixx.ndatabase.dbms.mongodb.MongoDBConfig;
 import com.nivixx.ndatabase.dbms.mysql.MysqlConfig;
@@ -15,6 +16,7 @@ public class NDatabaseConfig {
     protected MysqlConfig mysqlConfig;
     protected SqliteConfig sqliteConfig;
     protected MongoDBConfig mongoDBConfig;
+    protected CacheRepoConfig cacheRepoConfig;
 
     protected boolean isDebugMode = false;
     protected int idleThreadPoolSize = 1;
@@ -85,5 +87,13 @@ public class NDatabaseConfig {
 
     public void setIdleThreadPoolSize(int idleThreadPoolSize) {
         this.idleThreadPoolSize = idleThreadPoolSize;
+    }
+
+    public CacheRepoConfig getCacheRepoConfig() {
+        return cacheRepoConfig;
+    }
+
+    public void setCacheRepoConfig(CacheRepoConfig cacheRepoConfig) {
+        this.cacheRepoConfig = cacheRepoConfig;
     }
 }

--- a/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/reflection/NReflectionUtil.java
+++ b/ndatabase-core/src/main/java/com/nivixx/ndatabase/core/reflection/NReflectionUtil.java
@@ -29,7 +29,8 @@ public class NReflectionUtil {
     }
 
     public static boolean isNativeJavaClass(Class<?> type) {
-        return type.isPrimitive() || type.isEnum() || type.getPackage().getName().startsWith("java.");
+        Package classPackage = type.getPackage();
+        return type.isPrimitive() || type.isEnum() || (classPackage != null && classPackage.getName().startsWith("java."));
     }
 
     public static void resolveIndexedFieldsFromEntity(List<SingleNodePath> nodePaths, SingleNodePath parentNode, Object entity) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {

--- a/ndatabase-dbms-mariadb/src/main/java/com/nivixx/ndatabase/dbms/mariadb/HikariMariaConnectionPool.java
+++ b/ndatabase-dbms-mariadb/src/main/java/com/nivixx/ndatabase/dbms/mariadb/HikariMariaConnectionPool.java
@@ -1,8 +1,11 @@
 package com.nivixx.ndatabase.dbms.mariadb;
 
 import com.nivixx.ndatabase.dbms.jdbc.JdbcConnectionPool;
+import com.nivixx.ndatabase.platforms.coreplatform.logging.DBLogger;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import net.byteflux.libby.Library;
+import net.byteflux.libby.LibraryManager;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -10,20 +13,26 @@ import java.sql.SQLException;
 public class HikariMariaConnectionPool implements JdbcConnectionPool {
 
     private final MariaDBConfig mariaDBConfig;
+    private final LibraryManager libraryManager;
+    private final DBLogger dbLogger;
+
     private HikariDataSource dataSource;
+    private ClassLoader driverClassLoader;
 
-    public HikariMariaConnectionPool(MariaDBConfig mariaDBConfig) {
+    public HikariMariaConnectionPool(MariaDBConfig mariaDBConfig, DBLogger dbLogger, LibraryManager libraryManager) {
         this.mariaDBConfig = mariaDBConfig;
-    }
-
-
-    @Override
-    public Connection getConnection() throws SQLException {
-        return dataSource.getConnection();
+        this.dbLogger = dbLogger;
+        this.libraryManager = libraryManager;
     }
 
     @Override
     public void connect() throws Exception {
+        installMariaDBDriver();
+
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        thread.setContextClassLoader(driverClassLoader);
+
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl(mariaDBConfig.getHost());
         config.setDriverClassName(mariaDBConfig.getClassName());
@@ -34,6 +43,27 @@ public class HikariMariaConnectionPool implements JdbcConnectionPool {
         config.setConnectionTimeout(4000);
 
         dataSource = new HikariDataSource(config);
+
+        thread.setContextClassLoader(previousClassLoader);
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    private void installMariaDBDriver() {
+        Library lib = Library.builder()
+                .groupId("org{}mariadb{}jdbc")
+                .artifactId("mariadb-java-client")
+                .version("2.7.1")
+                .isolatedLoad(true)
+                .id("mariadb-java-client")
+                .build();
+        dbLogger.logInfo("Loading MariaDB driver...");
+        libraryManager.loadLibrary(lib);
+        driverClassLoader = libraryManager.getIsolatedClassLoaderOf("mariadb-java-client");
+        dbLogger.logInfo("MariaDB driver loaded successfully.");
     }
 
     public void closePool() {

--- a/ndatabase-dbms-mariadb/src/main/java/com/nivixx/ndatabase/dbms/mariadb/MariaDao.java
+++ b/ndatabase-dbms-mariadb/src/main/java/com/nivixx/ndatabase/dbms/mariadb/MariaDao.java
@@ -7,6 +7,7 @@ import com.nivixx.ndatabase.expressiontree.SingleNodePath;
 import com.nivixx.ndatabase.platforms.coreplatform.logging.DBLogger;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.text.MessageFormat;
@@ -38,9 +39,6 @@ public class MariaDao<K, V extends NEntity<K>> extends JdbcDao<K,V> {
     }
 
     protected void denormalizeFieldIntoColumn(Connection connection, SingleNodePath singleNodePath) throws SQLException {
-
-        // path.to.field
-        // MYSQL doesn't allow "." in column names
         String columnName = singleNodePath.getFullPath("_");
         String fieldPath = singleNodePath.getFullPath(".");
         Class<?> fieldType = singleNodePath.getLastNodeType();

--- a/ndatabase-packaging-jar/src/main/resources/config.yml
+++ b/ndatabase-packaging-jar/src/main/resources/config.yml
@@ -64,3 +64,28 @@ database:
     port: 27017
     user: ''
     pass: ''
+
+# Cache settings
+cache:
+  # The minutes to expire the object after accessing it from the cache
+  # When expired, the object will be committed to the database
+  expire-after-access-minutes: 30
+
+  # The maximum objects stored in the cache
+  maximum-size: 10000
+
+  # The timeout in seconds of getting an item in the cache
+  get-timeout-seconds: 5
+
+  # Changing the values to soft-references in the cache, allowing for purging of the values in a GC cycle
+  # This should be enabled if you have problems with memory
+  enable-soft-values: false
+
+  # Refreshes the value from the database asynchronously after writing
+  enable-refresh-after-write: false
+
+  # The amount of minutes after a write to refresh
+  refresh-after-write-minutes: 30
+
+  # Collects statistics about the cache
+  enable-stats: false

--- a/ndatabase-platforms/bukkit-platform/src/main/java/com/nivixx/ndatabase/platforms/bukkitplatform/BukkitPlatformLoader.java
+++ b/ndatabase-platforms/bukkit-platform/src/main/java/com/nivixx/ndatabase/platforms/bukkitplatform/BukkitPlatformLoader.java
@@ -1,6 +1,7 @@
 package com.nivixx.ndatabase.platforms.bukkitplatform;
 
 import com.nivixx.ndatabase.core.PlatformLoader;
+import com.nivixx.ndatabase.core.cache.CacheRepoConfig;
 import com.nivixx.ndatabase.core.config.*;
 import com.nivixx.ndatabase.dbms.mariadb.MariaDBConfig;
 import com.nivixx.ndatabase.dbms.mongodb.MongoDBConfig;
@@ -73,6 +74,24 @@ public class BukkitPlatformLoader extends PlatformLoader {
         mongoDBConfig.setUser(mongoDBUser);
         mongoDBConfig.setPass(mongoDBPass);
 
+        ConfigurationSection cache = config.getConfigurationSection("cache");
+        CacheRepoConfig cacheRepoConfig = new CacheRepoConfig();
+        long expireAfterAccessMinutes = cache.getLong("expire-after-access-minutes", 30);
+        long maximumSize = cache.getLong("maximum-size", 10_000);
+        int getTimeoutSeconds = cache.getInt("get-timeout-seconds", 5);
+        boolean enableSoftValues = cache.getBoolean("enable-soft-values", false);
+        boolean enableRefreshAfterWrite = cache.getBoolean("enable-refresh-after-write", false);
+        long refreshAfterWriteMinutes = cache.getLong("refresh-after-write-minutes", 30);
+        boolean enableStats = cache.getBoolean("enable-stats", false);
+
+        cacheRepoConfig.setExpireAfterAccessMinutes(expireAfterAccessMinutes);
+        cacheRepoConfig.setMaximumSize(maximumSize);
+        cacheRepoConfig.setGetTimeoutSeconds(getTimeoutSeconds);
+        cacheRepoConfig.setEnableSoftValues(enableSoftValues);
+        cacheRepoConfig.setEnableRefreshAfterWrite(enableRefreshAfterWrite);
+        cacheRepoConfig.setRefreshAfterWriteMinutes(refreshAfterWriteMinutes);
+        cacheRepoConfig.setEnableStats(enableStats);
+
         boolean debug = config.getBoolean("debug-mode", false);
 
         BukkitNDatabaseConfig bukkitNDatabaseConfig = new BukkitNDatabaseConfig();
@@ -83,6 +102,7 @@ public class BukkitPlatformLoader extends PlatformLoader {
         bukkitNDatabaseConfig.setMariaDBConfig(mariadbConfig);
         bukkitNDatabaseConfig.setSqliteConfig(sqliteConfig);
         bukkitNDatabaseConfig.setMongoDBConfig(mongoDBConfig);
+        bukkitNDatabaseConfig.setCacheRepoConfig(cacheRepoConfig);
 
         return bukkitNDatabaseConfig;
     }

--- a/ndatabase-platforms/bukkit-platform/src/main/java/com/nivixx/ndatabase/platforms/bukkitplatform/NDatabasePlugin.java
+++ b/ndatabase-platforms/bukkit-platform/src/main/java/com/nivixx/ndatabase/platforms/bukkitplatform/NDatabasePlugin.java
@@ -45,9 +45,4 @@ public class NDatabasePlugin extends JavaPlugin {
             throw new IllegalStateException("Could not init NDatabase bukkit plugin.", e);
         }
     }
-
-    @Override
-    public void onDisable() {
-        NDatabase.api().shutdown(); // Flush the cache properly
-    }
 }

--- a/ndatabase-platforms/bukkit-platform/src/main/java/com/nivixx/ndatabase/platforms/bukkitplatform/NDatabasePlugin.java
+++ b/ndatabase-platforms/bukkit-platform/src/main/java/com/nivixx/ndatabase/platforms/bukkitplatform/NDatabasePlugin.java
@@ -1,6 +1,8 @@
 package com.nivixx.ndatabase.platforms.bukkitplatform;
 
 import com.nivixx.ndatabase.api.NDatabase;
+import com.nivixx.ndatabase.api.NDatabaseAPI;
+import com.nivixx.ndatabase.api.repository.Repository;
 import com.nivixx.ndatabase.core.PlatformLoader;
 import com.nivixx.ndatabase.core.config.NDatabaseConfig;
 import org.bukkit.Bukkit;
@@ -42,5 +44,10 @@ public class NDatabasePlugin extends JavaPlugin {
         } catch (Throwable e) {
             throw new IllegalStateException("Could not init NDatabase bukkit plugin.", e);
         }
+    }
+
+    @Override
+    public void onDisable() {
+        NDatabase.api().shutdown(); // Flush the cache properly
     }
 }

--- a/ndatabase-platforms/sponge-platform/src/main/java/com/nivixx/ndatabase/platforms/spongeplatform/NDatabasePlugin.java
+++ b/ndatabase-platforms/sponge-platform/src/main/java/com/nivixx/ndatabase/platforms/spongeplatform/NDatabasePlugin.java
@@ -54,11 +54,6 @@ public class NDatabasePlugin {
         loadPlatform();
     }
 
-    @Listener
-    public void onDisable(final StoppedGameEvent event) {
-        NDatabase.api().shutdown(); // flush cache
-    }
-
     private void loadPlatform() {
 
         try {

--- a/ndatabase-platforms/sponge-platform/src/main/java/com/nivixx/ndatabase/platforms/spongeplatform/NDatabasePlugin.java
+++ b/ndatabase-platforms/sponge-platform/src/main/java/com/nivixx/ndatabase/platforms/spongeplatform/NDatabasePlugin.java
@@ -7,6 +7,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.config.ConfigRoot;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.lifecycle.ConstructPluginEvent;
+import org.spongepowered.api.event.lifecycle.StoppedGameEvent;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
 import org.spongepowered.plugin.PluginContainer;
@@ -51,6 +52,11 @@ public class NDatabasePlugin {
     public void onConstructPlugin(final ConstructPluginEvent event) {
         loadConfig();
         loadPlatform();
+    }
+
+    @Listener
+    public void onDisable(final StoppedGameEvent event) {
+        NDatabase.api().shutdown(); // flush cache
     }
 
     private void loadPlatform() {

--- a/ndatabase-platforms/sponge-platform/src/main/java/com/nivixx/ndatabase/platforms/spongeplatform/SpongePlatformLoader.java
+++ b/ndatabase-platforms/sponge-platform/src/main/java/com/nivixx/ndatabase/platforms/spongeplatform/SpongePlatformLoader.java
@@ -1,7 +1,9 @@
 package com.nivixx.ndatabase.platforms.spongeplatform;
 
 import com.nivixx.ndatabase.core.PlatformLoader;
-import com.nivixx.ndatabase.core.config.*;
+import com.nivixx.ndatabase.core.cache.CacheRepoConfig;
+import com.nivixx.ndatabase.core.config.DatabaseType;
+import com.nivixx.ndatabase.core.config.NDatabaseConfig;
 import com.nivixx.ndatabase.dbms.mariadb.MariaDBConfig;
 import com.nivixx.ndatabase.dbms.mongodb.MongoDBConfig;
 import com.nivixx.ndatabase.dbms.mysql.MysqlConfig;
@@ -82,6 +84,24 @@ public class SpongePlatformLoader extends PlatformLoader {
         mongoDBConfig.setDatabase(mongoDBNode.node("database").getString("ndatabase"));
         mongoDBConfig.setUser(mongoDBNode.node("user").getString(""));
         mongoDBConfig.setPass(mongoDBNode.node("pass").getString(""));
+        
+        ConfigurationNode cacheNode = config.node( "cache");
+        CacheRepoConfig cacheRepoConfig = new CacheRepoConfig();
+        long expireAfterAccessMinutes = cacheNode.node("expire-after-access-minutes").getLong(30);
+        long maximumSize = cacheNode.node("maximum-size").getLong(10_000);
+        int getTimeoutSeconds = cacheNode.node("get-timeout-seconds").getInt(5);
+        boolean enableSoftValues = cacheNode.node("enable-soft-values").getBoolean(false);
+        boolean enableRefreshAfterWrite = cacheNode.node("enable-refresh-after-write").getBoolean(false);
+        long refreshAfterWriteMinutes = cacheNode.node("refresh-after-write-minutes").getLong(30);
+        boolean enableStats = cacheNode.node("enable-stats").getBoolean(false);
+
+        cacheRepoConfig.setExpireAfterAccessMinutes(expireAfterAccessMinutes);
+        cacheRepoConfig.setMaximumSize(maximumSize);
+        cacheRepoConfig.setGetTimeoutSeconds(getTimeoutSeconds);
+        cacheRepoConfig.setEnableSoftValues(enableSoftValues);
+        cacheRepoConfig.setEnableRefreshAfterWrite(enableRefreshAfterWrite);
+        cacheRepoConfig.setRefreshAfterWriteMinutes(refreshAfterWriteMinutes);
+        cacheRepoConfig.setEnableStats(enableStats);
 
         // General Settings
         boolean debug = config.node("debug-mode").getBoolean(false);
@@ -94,6 +114,7 @@ public class SpongePlatformLoader extends PlatformLoader {
         spongeNDatabaseConfig.setMariaDBConfig(mariadbConfig);
         spongeNDatabaseConfig.setSqliteConfig(sqliteConfig);
         spongeNDatabaseConfig.setMongoDBConfig(mongoDBConfig);
+        spongeNDatabaseConfig.setCacheRepoConfig(cacheRepoConfig);
 
         return spongeNDatabaseConfig;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>3.1.8</version>
+            <version>2.9.3</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,12 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.14.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
This PR implements a caching system that users can enable, which caches the objects before entering the database. This improves the querying performance of the library. To enable the cache, users have to:

1. Annotate any objects they want to cache with `@UseCache`
```java
@NTable(name = "player_statistics", schema = "", catalog = "")
@UseCache // This enables the cache
public class PlayerStatsDTO extends NEntity<UUID> {

    @JsonProperty("killCount")
    private int kills;

    @JsonProperty("deathCount")
    private int deaths;

    @JsonProperty("lastLocation")
    private SerializedLocation lastLocation;

    public PlayerStatsDTO() { }
}
```

2. Add one line to the onDisable to flush the cache
```java
@Override
public void onDisable() {
    NDatabase.api().shutdown();
}
```

```mermaid
flowchart TD
    A[Client] --> B[CachedRepositoryImpl]
    B --> C{Cache Hit?}
    C -->|Yes| D[Return from Caffeine Cache]
    C -->|No| E[Load from DAO]
    E --> F[Store in Cache]
    F --> G[Return Value]
    
    B --> H[Write Operations]
    H -->|Insert/Update| I[Update Cache]
    I --> J[Cache Eviction]
    J -->|Removal Listener| K[Flush to DAO]

    subgraph Cache Configuration
    L[Expire After Access]
    M[Maximum Size]
    N[Soft Values Option]
    O[Refresh After Write]
    end
```

The cache is powered by caffeine, a high-performance java caching library (https://github.com/ben-manes/caffeine)
It makes use of their `AsyncLoadingCache` to run most operations on the async executor. 

Due to how Bukkit unloads classes on shutdown, the user must call the api shutdown, as their plugin will be unloaded before NDatabase is unloaded. 